### PR TITLE
Makes default link focus style less specific

### DIFF
--- a/css/base/base.css
+++ b/css/base/base.css
@@ -51,7 +51,7 @@ a:hover {
   text-decoration-thickness: max(3px, 0.1875rem, 0.12em);
 }
 
-a:not(.toolbar a):focus {
+a:not([class*="toolbar"]):focus {
   text-decoration: none;
   color: var(--color-black);
   outline: 3px solid transparent;


### PR DESCRIPTION
This change makes the selector less specific, though [it is still technically a bit more specific than e.g. `.call-out-box__link:focus`](https://polypane.app/css-specificity-calculator/#selector=a%3Anot(.toolbar%20a)%3Afocus%2C%20a%3Anot(%5Bclass*%3D%22toolbar%22%5D)%3Afocus%2C%20.call-out-box__link%3Afocus).

On the other hand, it seems close enough in specificity that [a selector with a simple class coming later in the cascade can override it as expected](https://codepen.io/bedlamhotel/pen/VwVMLBz).

This shouldn't interfere with whatever level of IE support the theme aims to maintain as [the `[class*="toolbar"]` selector has the same level of support as the original's `:not()`](https://caniuse.com/css-sel3).